### PR TITLE
Update link to custom rules docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ project-root/
         └── team-conventions.md
 ```
 
-[Learn more about custom rules](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/project-rules.html)
+[Learn more about custom rules](https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/third-party-context-project-rules.html)
 
 ## 🏁 Quick Start Guide
 


### PR DESCRIPTION
This page has been moved and appears to not have a proper redirect. Instead, it redirects to the "What is Amazon Q Developer?" page.

This change fixes it and points the link to https://docs.aws.amazon.com/amazonq/latest/qdeveloper-ug/third-party-context-project-rules.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
